### PR TITLE
feat: logit distribution charts for LigandMPNN, ESM2, and Amplify

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
  "serde_derive",
  "statrs",
  "strum",
- "strum_macros 0.28.0",
+ "strum_macros 0.26.4",
  "thiserror 2.0.18",
  "triple_accel",
  "vec_map",
@@ -952,7 +952,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1512,7 +1512,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1544,7 +1544,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -1803,7 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "ferritin-core"
 version = "0.3.5-dev"
-source = "git+https://github.com/ferritin-bio/ferritin.git#ffb6c00e3309d5295c447fa2c3cd2f2c1ea5d4b4"
+source = "git+https://github.com/ferritin-bio/ferritin.git#accec946dc4053a7de856e7bd8984bad562438d5"
 dependencies = [
  "anyhow",
  "itertools 0.15.0",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "ferritin-plms"
 version = "0.3.5-dev"
-source = "git+https://github.com/ferritin-bio/ferritin.git#ffb6c00e3309d5295c447fa2c3cd2f2c1ea5d4b4"
+source = "git+https://github.com/ferritin-bio/ferritin.git#accec946dc4053a7de856e7bd8984bad562438d5"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "ferritin-test-data"
 version = "0.3.5-dev"
-source = "git+https://github.com/ferritin-bio/ferritin.git#ffb6c00e3309d5295c447fa2c3cd2f2c1ea5d4b4"
+source = "git+https://github.com/ferritin-bio/ferritin.git#accec946dc4053a7de856e7bd8984bad562438d5"
 dependencies = [
  "tempfile",
 ]
@@ -3072,7 +3072,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3956,7 +3956,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4931,7 +4931,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5339,7 +5339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5396,7 +5396,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6559,7 +6559,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7669,7 +7669,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/src/commands/amplify.rs
+++ b/src-tauri/src/commands/amplify.rs
@@ -8,7 +8,7 @@ use ferritin_plms::{AmplifyModels, AmplifyRunner};
 
 #[tauri::command]
 pub fn get_amplify_logits(pdb_text: &str) -> Result<Vec<PseudoProbability>, String> {
-    let ac = load_structure_from_string(pdb_text, "pdb").map_err(|e| e.to_string())?;
+    let ac = load_structure_from_string(pdb_text, "cif").map_err(|e| e.to_string())?;
 
     let sequence = ac
         .iter_residues_aminoacid()
@@ -41,7 +41,6 @@ pub fn get_amplify_contact_map(pdb_text: &str) -> Result<Vec<ContactMap>, String
         .collect::<String>();
     let device = device(false).map_err(|e| e.to_string())?;
     let model = "120M"; // this should be a param
-    // println!("Device: {:?}", &device);
     let amp_model = match model {
         "120M" => AmplifyModels::AMP120M,
         "350M" => AmplifyModels::AMP350M,

--- a/src-tauri/src/commands/esm2_logits.rs
+++ b/src-tauri/src/commands/esm2_logits.rs
@@ -11,7 +11,8 @@ pub fn get_esm2_logits(pdb_seq: &str) -> Result<Vec<PseudoProbability>, String> 
     let dev = device(false).map_err(|e| e.to_string())?;
     let runner = ESM2Runner::load_model(ESM2Models::T6_8M, dev)
         .map_err(|e| e.to_string())?;
-    runner.get_pseudo_probabilities(&prot_seq).map_err(|e| e.to_string())
+    let result = runner.get_pseudo_probabilities(&prot_seq).map_err(|e| e.to_string())?;
+    Ok(result)
 }
 
 fn pdb_to_sequence(prot_seq: &str) -> Result<String> {

--- a/src-tauri/src/commands/ligandmpnn_logits.rs
+++ b/src-tauri/src/commands/ligandmpnn_logits.rs
@@ -13,10 +13,12 @@ pub fn get_ligmpnn_logits(
     let dev = device(false).map_err(|e| e.to_string())?;
 
     let ac = load_structure_from_string(pdb_text, "cif").map_err(|e| e.to_string())?;
+
     let features = ac.featurize_lmpnn(&dev).map_err(|e| format!("{:?}", e))?;
 
     let runner = ProteinMPNNRunner::load_model(ProteinMPNNModels::V48_020, dev)
         .map_err(|e| e.to_string())?;
+
     let all_probs = runner
         .get_pseudo_probabilities(&features)
         .map_err(|e| e.to_string())?;

--- a/src/lib/components/structure_components/amplify_logits.svelte
+++ b/src/lib/components/structure_components/amplify_logits.svelte
@@ -19,22 +19,20 @@
         error = null;
 
         try {
-            logits = await invoke("get_amplify_logits", {
+            const result = await invoke("get_amplify_logits", {
                 pdbText: pdbText,
             });
-            console.log(logits);
+            logits = result;
         } catch (e) {
-            error = e.message;
-            console.error("Error fetching logits:", e);
+            error = typeof e === "string" ? e : (e?.message ?? String(e));
         } finally {
             loading = false;
         }
     }
 
-    function myplot(node) {
-        let plot;
-        function createPlot() {
-            plot = Plot.plot({
+    function myplot(node, data) {
+        function createPlot(data) {
+            const plot = Plot.plot({
                 width: node.clientWidth,
                 height: node.clientHeight,
                 margin: 20,
@@ -52,13 +50,13 @@
                 x: {
                     tickFormat: "",
                     labelOffset: 30,
-                    ticks: (logits || []).reduce((acc, curr) => {
+                    ticks: (data || []).reduce((acc, curr) => {
                         const pos = curr.position;
                         return pos % 10 === 0 ? [...acc, pos] : acc;
                     }, []),
                 },
                 marks: [
-                    Plot.cell(logits || [], {
+                    Plot.cell(data || [], {
                         x: "position",
                         y: "amino_acid",
                         fill: "pseudo_prob",
@@ -70,8 +68,11 @@
             node.appendChild(plot);
         }
 
-        createPlot();
+        createPlot(data);
         return {
+            update(newData) {
+                createPlot(newData);
+            },
             destroy() {
                 node.innerHTML = "";
             },
@@ -87,7 +88,7 @@
     <div class="no-data">Select a residue to view LigMPNN predictions</div>
 {:else}
     <div
-        use:myplot
+        use:myplot={logits}
         style="width: 100%; height: 100%; min-height: 400px;"
         class="plot-container"
     ></div>

--- a/src/lib/components/structure_components/esm2_logits.svelte
+++ b/src/lib/components/structure_components/esm2_logits.svelte
@@ -19,22 +19,20 @@
         error = null;
 
         try {
-            logits = await invoke("get_esm2_logits", {
+            const result = await invoke("get_esm2_logits", {
                 pdbSeq: pdbText,
             });
-            console.log(logits);
+            logits = result;
         } catch (e) {
-            error = e.message;
-            console.error("Error fetching logits:", e);
+            error = typeof e === "string" ? e : (e?.message ?? String(e));
         } finally {
             loading = false;
         }
     }
 
-    function myplot(node) {
-        let plot;
-        function createPlot() {
-            plot = Plot.plot({
+    function myplot(node, data) {
+        function createPlot(data) {
+            const plot = Plot.plot({
                 width: node.clientWidth,
                 height: node.clientHeight,
                 margin: 20,
@@ -52,13 +50,13 @@
                 x: {
                     tickFormat: "",
                     labelOffset: 30,
-                    ticks: (logits || []).reduce((acc, curr) => {
+                    ticks: (data || []).reduce((acc, curr) => {
                         const pos = curr.position;
                         return pos % 10 === 0 ? [...acc, pos] : acc;
                     }, []),
                 },
                 marks: [
-                    Plot.cell(logits || [], {
+                    Plot.cell(data || [], {
                         x: "position",
                         y: "amino_acid",
                         fill: "pseudo_prob",
@@ -70,8 +68,11 @@
             node.appendChild(plot);
         }
 
-        createPlot();
+        createPlot(data);
         return {
+            update(newData) {
+                createPlot(newData);
+            },
             destroy() {
                 node.innerHTML = "";
             },
@@ -87,7 +88,7 @@
     <div class="no-data">Select a residue to view LigMPNN predictions</div>
 {:else}
     <div
-        use:myplot
+        use:myplot={logits}
         style="width: 100%; height: 100%; min-height: 400px;"
         class="plot-container"
     ></div>

--- a/src/lib/components/structure_components/ligand_mpnn.svelte
+++ b/src/lib/components/structure_components/ligand_mpnn.svelte
@@ -19,24 +19,22 @@
         error = null;
 
         try {
-            logits = await invoke("get_ligmpnn_logits", {
+            const result = await invoke("get_ligmpnn_logits", {
                 pdbText,
                 position,
                 temp: temperature,
             });
+            logits = result;
         } catch (e) {
-            error = e.message;
-            console.error("Error fetching logits:", e);
+            error = typeof e === "string" ? e : (e?.message ?? String(e));
         } finally {
             loading = false;
         }
     }
 
-    function myplot(node) {
-        let plot;
-
-        function createPlot() {
-            plot = Plot.plot({
+    function myplot(node, data) {
+        function createPlot(data) {
+            const plot = Plot.plot({
                 width: node.clientWidth,
                 height: node.clientHeight,
                 margin: 20,
@@ -47,7 +45,7 @@
                     overflow: "visible",
                 },
                 marks: [
-                    Plot.barY(logits || [], {
+                    Plot.barY(data || [], {
                         x: "amino_acid",
                         y: "pseudo_prob",
                         fill: "orange",
@@ -69,8 +67,11 @@
             node.appendChild(plot);
         }
 
-        createPlot();
+        createPlot(data);
         return {
+            update(newData) {
+                createPlot(newData);
+            },
             destroy() {
                 node.innerHTML = "";
             },
@@ -86,7 +87,7 @@
     <div class="no-data">Select a residue to view LigMPNN predictions</div>
 {:else}
     <div
-        use:myplot
+        use:myplot={logits}
         style="width: 100%; height: 100%; min-height: 400px;"
         class="plot-container"
     ></div>


### PR DESCRIPTION
- LigandMPNN bar chart shows per-residue amino acid probabilities; re-renders on each residue click via use:myplot update() callback
- ESM2 and Amplify heatmap components follow same pattern
- Tauri error strings now surfaced correctly (plain string vs Error object)
- Amplify command fixed to parse CIF format (frontend sends .cif from RCSB)
- Cargo.lock updated to ferritin@accec94 which includes upstream fixes: sequence mask initialized to ones (was zeros → NaN logits), zero-ligand Metal crash guard, and correct HF Hub repo for weights